### PR TITLE
fix(webpack): pass dependencies to cached css files

### DIFF
--- a/.changeset/curly-yaks-turn.md
+++ b/.changeset/curly-yaks-turn.md
@@ -1,0 +1,7 @@
+---
+'@linaria/webpack4-loader': patch
+'@linaria/webpack5-loader': patch
+'@linaria/webpack-loader': patch
+---
+
+Watch dependencies from cached css files in webpack watch mode.

--- a/docs/BUNDLERS_INTEGRATION.md
+++ b/docs/BUNDLERS_INTEGRATION.md
@@ -184,9 +184,13 @@ The loader accepts the following options:
   > ```
   > interface ICache {
   >   get: (key: string) => Promise<string>;
-  >   set: (key: string, value: string) => Promise<void>
+  >   set: (key: string, value: string) => Promise<void>;
+  >   getDependencies?: (key: string) => Promise<string[]>;
+  >   setDependencies?: (key: string, value: string[]) => Promise<void>;
   > }
   > ```
+
+  When running webpack with `--watch`, `getDependencies` and `setDependencies` will be used to carry dependencies of the Linaria JavaScript source to the generated css output, ensuring both are rebuilt when dependencies change. When these methods are not present on the cache instance, dependencies for the css output will be ignored and may get out of sync with the JavaScript output. Linaria's default memory cache does not have this issue.
 
 - `extension: string` (default: `'.linaria.css'`):
 

--- a/packages/webpack4-loader/package.json
+++ b/packages/webpack4-loader/package.json
@@ -15,7 +15,7 @@
     "@types/loader-utils": "^1.1.3",
     "@types/mkdirp": "^0.5.2",
     "@types/node": "^17.0.39",
-    "@types/webpack": "^4.41.26",
+    "@types/webpack": "^4.41.33",
     "source-map": "^0.7.3"
   },
   "engines": {

--- a/packages/webpack4-loader/src/cache.ts
+++ b/packages/webpack4-loader/src/cache.ts
@@ -1,6 +1,8 @@
 export interface ICache {
   get: (key: string) => Promise<string>;
   set: (key: string, value: string) => Promise<void>;
+  getDependencies?: (key: string) => Promise<string[]>;
+  setDependencies?: (key: string, value: string[]) => Promise<void>;
 }
 
 // memory cache, which is the default cache implementation in Linaria
@@ -8,12 +10,23 @@ export interface ICache {
 class MemoryCache implements ICache {
   private cache: Map<string, string> = new Map();
 
+  private dependenciesCache: Map<string, string[]> = new Map();
+
   public get(key: string): Promise<string> {
     return Promise.resolve(this.cache.get(key) ?? '');
   }
 
   public set(key: string, value: string): Promise<void> {
     this.cache.set(key, value);
+    return Promise.resolve();
+  }
+
+  public getDependencies(key: string): Promise<string[]> {
+    return Promise.resolve(this.dependenciesCache.get(key) ?? []);
+  }
+
+  public setDependencies(key: string, value: string[]): Promise<void> {
+    this.dependenciesCache.set(key, value);
     return Promise.resolve();
   }
 }

--- a/packages/webpack5-loader/src/cache.ts
+++ b/packages/webpack5-loader/src/cache.ts
@@ -1,6 +1,8 @@
 export interface ICache {
   get: (key: string) => Promise<string>;
   set: (key: string, value: string) => Promise<void>;
+  getDependencies?: (key: string) => Promise<string[]>;
+  setDependencies?: (key: string, value: string[]) => Promise<void>;
 }
 
 // memory cache, which is the default cache implementation in Linaria
@@ -8,12 +10,23 @@ export interface ICache {
 class MemoryCache implements ICache {
   private cache: Map<string, string> = new Map();
 
+  private dependenciesCache: Map<string, string[]> = new Map();
+
   public get(key: string): Promise<string> {
     return Promise.resolve(this.cache.get(key) ?? '');
   }
 
   public set(key: string, value: string): Promise<void> {
     this.cache.set(key, value);
+    return Promise.resolve();
+  }
+
+  public getDependencies(key: string): Promise<string[]> {
+    return Promise.resolve(this.dependenciesCache.get(key) ?? []);
+  }
+
+  public setDependencies(key: string, value: string[]): Promise<void> {
+    this.dependenciesCache.set(key, value);
     return Promise.resolve();
   }
 }

--- a/packages/webpack5-loader/src/outputCssLoader.ts
+++ b/packages/webpack5-loader/src/outputCssLoader.ts
@@ -3,13 +3,25 @@ import type webpack from 'webpack';
 import type { ICache } from './cache';
 import { getCacheInstance } from './cache';
 
-export default function outputCssLoader(
+export default async function outputCssLoader(
   this: webpack.LoaderContext<{ cacheProvider: string | ICache | undefined }>
 ) {
   this.async();
   const { cacheProvider } = this.getOptions();
-  getCacheInstance(cacheProvider)
-    .then((cacheInstance) => cacheInstance.get(this.resourcePath))
-    .then((result) => this.callback(null, result))
-    .catch((err: Error) => this.callback(err));
+
+  try {
+    const cacheInstance = await getCacheInstance(cacheProvider);
+
+    const result = await cacheInstance.get(this.resourcePath);
+    const dependencies =
+      (await cacheInstance.getDependencies?.(this.resourcePath)) ?? [];
+
+    dependencies.forEach((dependency) => {
+      this.addDependency(dependency);
+    });
+
+    this.callback(null, result);
+  } catch (err) {
+    this.callback(err as Error);
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -668,7 +668,7 @@ importers:
       '@types/loader-utils': ^1.1.3
       '@types/mkdirp': ^0.5.2
       '@types/node': ^17.0.39
-      '@types/webpack': ^4.41.26
+      '@types/webpack': ^4.41.33
       enhanced-resolve: ^4.1.0
       loader-utils: ^1.2.3
       mkdirp: ^0.5.1
@@ -684,7 +684,7 @@ importers:
       '@types/loader-utils': 1.1.6
       '@types/mkdirp': 0.5.2
       '@types/node': 17.0.39
-      '@types/webpack': 4.41.32
+      '@types/webpack': 4.41.33
       source-map: 0.7.3
 
   packages/webpack5-loader:
@@ -2771,22 +2771,22 @@ packages:
       postcss-selector-parser: 6.0.10
     dev: false
 
-  /@definitelytyped/header-parser/0.0.132:
-    resolution: {integrity: sha512-xjj2ahDRAf9pB77xFSfrCzSIIjksAieDVfc6KcrfLXHzcA3FJ5tyXWCljWmTYBR1bnknrp8XVvosC7IiUN66jg==}
+  /@definitelytyped/header-parser/0.0.133:
+    resolution: {integrity: sha512-Mv1F76WeuzdO9qrVi9hRQHjbwmb9bU5Gw5jdmUVWHma68IeiMNYlcMeKwQua7yVM+zRvihWvEI9s4O5NxY/gAA==}
     dependencies:
-      '@definitelytyped/typescript-versions': 0.0.132
+      '@definitelytyped/typescript-versions': 0.0.133
       '@types/parsimmon': 1.10.6
       parsimmon: 1.18.1
     dev: true
 
-  /@definitelytyped/typescript-versions/0.0.132:
-    resolution: {integrity: sha512-jHe+l/djS7RGQ+YWKPGuzfh4WXKPeRmBJ+4QHXpB4moahEyK86nMaTmdqYZliO8rD4HUEK20/4V/g+uUrG1GxQ==}
+  /@definitelytyped/typescript-versions/0.0.133:
+    resolution: {integrity: sha512-tfitkEgTmOBXDfgzzlxoXSYsUqIimKV2rdLd+61Mfzcp34yZ3bdhS8+4Gnc6rdMR4+V/sa3yvy5lYZLK2HP11Q==}
     dev: true
 
-  /@definitelytyped/utils/0.0.132:
-    resolution: {integrity: sha512-freIvPdHEjuFqa+W/7T6m2XzxZRYe5LYiBa2tmWGQ7qwZhbBnDyZN8y0k7fe/YP+LRU5ahho7BBVrPeD4t+U7w==}
+  /@definitelytyped/utils/0.0.133:
+    resolution: {integrity: sha512-aRCduwfl3l+3FJDGGDA5HDVF5FwKLYVEFQ5xKEi8Yz4RZqpAXRN7xKAuQiGx1yQ57CkMRaaOgLrcGoYECSBWcA==}
     dependencies:
-      '@definitelytyped/typescript-versions': 0.0.132
+      '@definitelytyped/typescript-versions': 0.0.133
       '@qiwi/npm-registry-client': 8.9.1
       '@types/node': 14.18.20
       charm: 1.0.2
@@ -3521,7 +3521,7 @@ packages:
     resolution: {integrity: sha512-0U4S5kLpm3Cu9YkO46JrmujS2abL2tWsxA1SR8km6X0a1E96tfPu34zRdQSZsJ6dfRYwQpmuKmy9Mx2Od7AXag==}
     dependencies:
       '@types/node': 17.0.39
-      '@types/webpack': 4.41.32
+      '@types/webpack': 4.41.33
     dev: true
 
   /@types/mdast/3.0.10:
@@ -3678,8 +3678,8 @@ packages:
       source-map: 0.7.3
     dev: true
 
-  /@types/webpack/4.41.32:
-    resolution: {integrity: sha512-cb+0ioil/7oz5//7tZUSwbrSAN/NWHrQylz5cW8G0dWTcF/g+/dSdMlKVZspBYuMAN1+WnwHrkxiRrLcwd0Heg==}
+  /@types/webpack/4.41.33:
+    resolution: {integrity: sha512-PPajH64Ft2vWevkerISMtnZ8rTs4YmRbs+23c402J0INmxDKCrhZNvwZYtzx96gY2wAtXdrK1BS2fiC8MlLr3g==}
     dependencies:
       '@types/node': 17.0.39
       '@types/tapable': 1.0.8
@@ -5611,7 +5611,7 @@ packages:
     peerDependencies:
       typescript: '*'
     dependencies:
-      '@definitelytyped/header-parser': 0.0.132
+      '@definitelytyped/header-parser': 0.0.133
       command-exists: 1.2.9
       rimraf: 3.0.2
       semver: 6.3.0
@@ -5627,9 +5627,9 @@ packages:
     peerDependencies:
       typescript: '>= 3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.7.0-dev || >= 3.8.0-dev || >= 3.9.0-dev || >= 4.0.0-dev'
     dependencies:
-      '@definitelytyped/header-parser': 0.0.132
-      '@definitelytyped/typescript-versions': 0.0.132
-      '@definitelytyped/utils': 0.0.132
+      '@definitelytyped/header-parser': 0.0.133
+      '@definitelytyped/typescript-versions': 0.0.133
+      '@definitelytyped/utils': 0.0.133
       dts-critic: 3.3.11_typescript@4.7.4
       fs-extra: 6.0.1
       json-stable-stringify: 1.0.1


### PR DESCRIPTION
***DRAFT***

When webpack is run with `--watch` or with `webpack-dev-server`, the generated css output will not be updated when dependencies imported into Linaria JavaScript source files, causing the resulting output to be stale.

The changes to the `ICache` interfaces are backward-compatible to avoid breaking any external implementations provided to the webpack builders using the prior versions of the interfaces.

<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
Motivation and Test plan are mandatory.
-->

## Motivation

This _should_ address num1077.

## Summary

Webpack allows adding dependencies to modules. Since the `*.linaria.js` and `*.linaria.css` files need to be in sync in order to generate the correct changes in webpack's watch mode, the css loader needs to have access to that dependency list so that _it_ can tell webpack when it needs to change. The logical place for this was in the cache provider. But rather than update the cached data type and break the contract on the api, I opted to add an optional set of methods which implementers don't need to worry about unless they need to address this same issue using their own cache implementation.

## Test plan

The proof-of-concept for this fix came from hacking the `@linaria/webpack5-loader` distribution used in another project. 